### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/SalemC/creagle-compiler/security/code-scanning/1](https://github.com/SalemC/creagle-compiler/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/node.js.yml` at the workflow root level so it applies to all jobs (current and future unless overridden). For this CI workflow, the minimal required permission is:

- `contents: read`

Best single fix without changing functionality:
- Insert `permissions:` after the `on:` trigger block and before `jobs:`.
- Set `contents: read`.
- Do not change steps, actions, triggers, or job behavior.

No imports, methods, or dependencies are needed (YAML workflow metadata only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
